### PR TITLE
fix(missions): sandy missions gil reward multiplied by 10

### DIFF
--- a/scripts/missions/sandoria/1_3_Save_the_Children.lua
+++ b/scripts/missions/sandoria/1_3_Save_the_Children.lua
@@ -43,7 +43,7 @@ end
 local handleCompleteEventFinish = function(player, csid, option, npc)
     if not player:hasCompletedMission(mission.areaId, mission.missionId) then
         player:setRank(2)
-        npcUtil.giveCurrency(player, "gil", 1000)
+        npcUtil.giveCurrency(player, "gil", 10000)
     else
         player:addRankPoints(250)
     end

--- a/scripts/missions/sandoria/2_3_0_Journey_Abroad.lua
+++ b/scripts/missions/sandoria/2_3_0_Journey_Abroad.lua
@@ -26,7 +26,7 @@ local mission = Mission:new(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.J
 mission.reward =
 {
     rank    = 3,
-    gil     = 3000,
+    gil     = 30000,
     keyItem = xi.ki.ADVENTURERS_CERTIFICATE,
     title   = xi.title.CERTIFIED_ADVENTURER,
 }

--- a/scripts/missions/sandoria/3_3_Appointment_to_Jeuno.lua
+++ b/scripts/missions/sandoria/3_3_Appointment_to_Jeuno.lua
@@ -28,7 +28,7 @@ local mission = Mission:new(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.A
 
 mission.reward =
 {
-    gil = 5000,
+    gil = 50000,
     rank = 4,
 }
 

--- a/scripts/missions/sandoria/4_1_Magicite.lua
+++ b/scripts/missions/sandoria/4_1_Magicite.lua
@@ -28,7 +28,7 @@ local mission = Mission:new(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.M
 mission.reward =
 {
     rank = 5,
-    gil = 10000,
+    gil = 100000,
     keyItem = xi.ki.MESSAGE_TO_JEUNO_SANDORIA,
 }
 
@@ -124,7 +124,7 @@ mission.sections =
                     player:delKeyItem(xi.ki.MAGICITE_ORASTONE)
 
                     if player:hasKeyItem(xi.ki.AIRSHIP_PASS) then
-                        npcUtil.giveCurrency(player, "gil", 20000)
+                        npcUtil.giveCurrency(player, "gil", 200000)
                     else
                         npcUtil.giveKeyItem(player, xi.ki.AIRSHIP_PASS)
                     end

--- a/scripts/missions/sandoria/5_2_The_Shadow_Lord.lua
+++ b/scripts/missions/sandoria/5_2_The_Shadow_Lord.lua
@@ -26,7 +26,7 @@ local mission = Mission:new(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.T
 mission.reward =
 {
     -- Rank 6 is awarded prior to completing mission
-    gil = 20000,
+    gil = 200000,
 }
 
 local handleAcceptMission = function(player, csid, option, npc)

--- a/scripts/missions/sandoria/6_2_Ranperres_Final_Rest.lua
+++ b/scripts/missions/sandoria/6_2_Ranperres_Final_Rest.lua
@@ -27,7 +27,7 @@ local mission = Mission:new(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.R
 mission.reward =
 {
     rank = 7,
-    gil = 40000,
+    gil = 400000,
 }
 
 local handleAcceptMission = function(player, csid, option, npc)

--- a/scripts/missions/sandoria/7_2_The_Secret_Weapon.lua
+++ b/scripts/missions/sandoria/7_2_The_Secret_Weapon.lua
@@ -21,7 +21,7 @@ local mission = Mission:new(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.T
 mission.reward =
 {
     rank = 8,
-    gil = 60000,
+    gil = 600000,
 }
 
 local handleAcceptMission = function(player, csid, option, npc)

--- a/scripts/missions/sandoria/8_2_Lightbringer.lua
+++ b/scripts/missions/sandoria/8_2_Lightbringer.lua
@@ -33,7 +33,7 @@ local mission = Mission:new(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.L
 mission.reward =
 {
     rank = 9,
-    gil = 80000,
+    gil = 800000,
 }
 
 local handleAcceptMission = function(player, csid, option, npc)

--- a/scripts/missions/sandoria/9_2_The_Heir_to_the_Light.lua
+++ b/scripts/missions/sandoria/9_2_The_Heir_to_the_Light.lua
@@ -24,7 +24,7 @@ local mission = Mission:new(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.T
 mission.reward =
 {
     rank = 10,
-    gil = 100000,
+    gil = 1000000,
     title = xi.title.SAN_DORIAN_ROYAL_HEIR,
 }
 


### PR DESCRIPTION
While migrating to landsandboat the missions functionality has been
partially migrated to a new system.  This migrates our x10 adjustment
for sandy missions in the new system.