### PR TITLE
feat(movement): apply city movement speed bonus

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -223,6 +223,13 @@ int32 CBattleEntity::GetMaxMP() const
 uint8 CBattleEntity::GetSpeed()
 {
     int16 startingSpeed = isMounted() ? 40 + map_config.mount_speed_mod : speed;
+
+    //add city movement bonus
+    if (objType == TYPE_PC || objtype == TYPE_PET)
+    {
+        startingSpeed = loc.zone->GetType() == ZONE_TYPE::CITY) ? startingSpeed += map_config.city_speed_mod : startingSpeed
+    }
+
     // Mod::MOVE (169)
     // Mod::MOUNT_MOVE (972)
     Mod mod = isMounted() ? Mod::MOUNT_MOVE : Mod::MOVE;

--- a/src/map/map.cpp
+++ b/src/map/map.cpp
@@ -1022,6 +1022,7 @@ int32 map_config_default()
     map_config.all_jobs_widescan           = true;
     map_config.speed_mod                   = 0;
     map_config.mount_speed_mod             = 0;
+    map_config.city_speed_mod              = 0;
     map_config.mob_speed_mod               = 0;
     map_config.skillup_chance_multiplier   = 1.0f;
     map_config.craft_chance_multiplier     = 1.0f;
@@ -1341,6 +1342,10 @@ int32 map_config_read(const int8* cfgName)
         {
             map_config.speed_mod = atoi(w2);
         }
+        else if (strcmp(w1, "city_speed_mod") == 0)
+        {
+            map_config.city_speed_mod = atoi(w2);
+        }
         else if (strcmp(w1, "mount_speed_mod") == 0)
         {
             map_config.mount_speed_mod = atoi(w2);
@@ -1504,6 +1509,10 @@ int32 map_config_read(const int8* cfgName)
         else if (strcmp(w1, "daily_tally_limit") == 0)
         {
             map_config.daily_tally_limit = atoi(w2);
+        }
+        else if (strcmp(w1, "blue_spell_learn_chance") == 0)
+        {
+            map_config.blue_spell_learn_chance = atoi(w2);
         }
         else
         {

--- a/src/map/map.h
+++ b/src/map/map.h
@@ -91,6 +91,7 @@ struct map_config_t
     bool        disable_gear_scaling;        // Disables ability to equip higher level gear when level cap/sync effect is on player.
     bool        all_jobs_widescan;           // Enable/disable jobs other than BST and RNG having widescan.
     int8        speed_mod;                   // Modifier to add to player speed
+    int8        city_speed_mod;              // Modifier to add to player speed when in a city
     int8        mount_speed_mod;             // Modifier to add to mount speed
     int8        mob_speed_mod;               // Modifier to add to monster speed
     float       skillup_chance_multiplier;   // Constant used in the skillup formula that has a strong effect on skill-up rates
@@ -151,6 +152,7 @@ struct map_config_t
     bool        anticheat_jail_disable; // Globally disable auto-jailing by the anti-cheat system
     uint16      daily_tally_amount;     // Amount of daily tally points given at midnight for Gobbie Mystery Box
     uint16      daily_tally_limit;      // Upper limit of daily tally points for Gobbie Mystery Box
+    int16  blue_spell_learn_chance;     // Increase chance to learn blue spells.
 };
 
 /************************************************************************


### PR DESCRIPTION
This applies the city movement speed bonus from metal configuration
changes.